### PR TITLE
Fixed replyrate calculation

### DIFF
--- a/lib/pyborg/pyborg-irc.py
+++ b/lib/pyborg/pyborg-irc.py
@@ -323,6 +323,13 @@ class ModIRC(SingleServerIRCBot):
         if source == self.settings.myname: return
 
 
+        # We want replies reply_chance%, if speaking is on
+        replyrate = self.settings.speaking * self.settings.reply_chance
+
+        # double reply chance if the text contains our nickname :-)
+        if body.lower().find(self.settings.myname.lower()) != -1:
+            replyrate = replyrate * 2
+
         #replace nicknames by "#nick"
         if e.eventtype() == "pubmsg":
             escaped_users = map(re.escape, self.channels[target].users())
@@ -352,13 +359,6 @@ class ModIRC(SingleServerIRCBot):
         if body[0] == "<" or body[0:1] == "\"" or body[0:1] == " <":
             print "Ignoring quoted text"
             return
-
-        # We want replies reply_chance%, if speaking is on
-        replyrate = self.settings.speaking * self.settings.reply_chance
-
-        # double reply chance if the text contains our nickname :-)
-        if body.lower().find(self.settings.myname.lower()) != -1:
-            replyrate = replyrate * 2
 
         # Always reply to private messages
         if e.eventtype() == "privmsg":


### PR DESCRIPTION
There was an issue where nicknames are parsed out of the message body
before calculating the replyrate.  The chance of a reply should be
doubled if the message contained the bots name.  This issues has been
resolved by moving the replyrate calculation before the nicks are
removed.