### PR TITLE
fixing nick/name lookup for increasing reply rate

### DIFF
--- a/lib/pyborg/pyborg-irc.py
+++ b/lib/pyborg/pyborg-irc.py
@@ -315,6 +315,11 @@ class ModIRC(SingleServerIRCBot):
         #remove special irc fonts chars
         body = re.sub("[\x02\xa0]", "", body)
 
+        isMe = False
+        if (body.lower().find(self.settings.myname.lower()) >= 0):
+            isMe = True
+            print("it is me")
+
         # WHOOHOOO!!
         if target == self.settings.myname or source == self.settings.myname:
             print "[%s] <%s> > %s> %s" % (get_time(), source, target, body)
@@ -357,8 +362,12 @@ class ModIRC(SingleServerIRCBot):
         replyrate = self.settings.speaking * self.settings.reply_chance
 
         # double reply chance if the text contains our nickname :-)
-        if body.lower().find(self.settings.myname.lower()) != -1:
-            replyrate = replyrate * 2
+        #if self.settings.myname.lower() in body.lower():
+        print(body.lower())
+        print(self.settings.myname.lower())
+        if isMe:
+            #replyrate = replyrate * 2
+            replyrate = 100
 
         # Always reply to private messages
         if e.eventtype() == "privmsg":

--- a/lib/pyborg/pyborg-irc.py
+++ b/lib/pyborg/pyborg-irc.py
@@ -366,8 +366,7 @@ class ModIRC(SingleServerIRCBot):
         print(body.lower())
         print(self.settings.myname.lower())
         if isMe:
-            #replyrate = replyrate * 2
-            replyrate = 100
+            replyrate = replyrate * 2
 
         # Always reply to private messages
         if e.eventtype() == "privmsg":


### PR DESCRIPTION
The code for checking whether the PyBot's nick was in the body happened after the replacement of all the nicks with '#nick'.  I added a flag that would save whether or not the nick was in the body.