### PR TITLE
Added delay command for IRC

### DIFF
--- a/lib/pyborg/pyborg-irc.py
+++ b/lib/pyborg/pyborg-irc.py
@@ -378,9 +378,8 @@ class ModIRC(SingleServerIRCBot):
                 if self.irc_commands(body, source, target, c, e) == 1:return
 
         # Calculate delay
-        if len(self.settings.delay) == 1:
-            delay = self.settings.delay[0]
-        elif len(self.settings.delay) == 2:
+        delay = self.settings.delay[0]
+        if len(self.settings.delay) == 2:
             delay = random.randint(self.settings.delay[0], self.settings.delay[1])
 
 

--- a/lib/pyborg/pyborg.py
+++ b/lib/pyborg/pyborg.py
@@ -295,7 +295,7 @@ class pyborg:
             finally:
                 self.saving = False
 
-    def process_msg(self, io_module, body, replyrate, learn, args, owner = 0):
+    def process_msg(self, io_module, body, replyrate, learn, args, owner = 0, delay = 0):
         """
         Process message 'body' and pass back to IO module with args.
         If owner==1 allow owner commands.
@@ -328,9 +328,11 @@ class pyborg:
             elif self.settings.process_with == "megahal" and self.settings.learning == 1:
                 mh_python.learn(body)
 
-
         # Make a reply if desired
         if random.randint(0, 99) < replyrate:
+
+            if delay > 0:
+                time.sleep(delay)
 
             message = ""
 

--- a/lib/pyborg/pyborg.py
+++ b/lib/pyborg/pyborg.py
@@ -328,6 +328,7 @@ class pyborg:
             elif self.settings.process_with == "megahal" and self.settings.learning == 1:
                 mh_python.learn(body)
 
+
         # Make a reply if desired
         if random.randint(0, 99) < replyrate:
 


### PR DESCRIPTION
Hello! I added another command that will delay the bots response for a number of seconds in IRC. This will make the bot seem more human by simulating time to think and type.

For example, `!delay 7` will add a seven second delay to the bots response. `!delay 7 11` will set a range, where the delay will be a random number between 7 and 11. Set the delay back to 0 seconds with `!delay 0`

Thanks!